### PR TITLE
#171012192 Admin can change announcement status

### DIFF
--- a/server/v2/controllers/admin.controller.js
+++ b/server/v2/controllers/admin.controller.js
@@ -41,6 +41,45 @@ class adminController {
       });
     }
   }
+
+  static async changeStatus(req, res) {
+    const token = req.headers.authorization.split(' ')[1];
+    const decoded = jwtDecode(token);
+
+    if (decoded.user.isadmin === true) {
+      const exist = await pool.query(announcementQueries.getOneUpdate, [
+        req.params.id
+      ]);
+
+      if (exist.rowCount === 0) {
+        return res.status(404).json({
+          status: 404,
+          errorMessage: 'Announcement not found!'
+        });
+      }
+
+      const updated = await pool.query(announcementQueries.changeStatus, [
+        req.body.status,
+        req.params.id
+      ]);
+
+      if (updated.rowCount > 0) {
+        const exists = await pool.query(announcementQueries.getOneUpdate, [
+          req.params.id
+        ]);
+        return res.status(202).json({
+          status: 202,
+          message: 'Status of announcement changed!',
+          data: exists.rows[0]
+        });
+      }
+    } else {
+      res.status(401).json({
+        status: 401,
+        errorMessage: 'You are not allowed for this action!'
+      });
+    }
+  }
 }
 
 export default adminController;

--- a/server/v2/models/announcement.query.js
+++ b/server/v2/models/announcement.query.js
@@ -17,6 +17,7 @@ const getallbyState = 'SELECT * FROM announcements WHERE status=$1';
 const getAnnouncement =
   'SELECT text, startdate, enddate FROM announcements WHERE id=$1';
 const deleteAnnouncement = 'DELETE FROM announcements WHERE id=$1';
+const changeStatus = 'UPDATE announcements SET status=$1 WHERE id=$2';
 export default {
   createAnnouncement,
   getOne,
@@ -25,5 +26,6 @@ export default {
   getmyAnnouncements,
   getallbyState,
   getAnnouncement,
-  deleteAnnouncement
+  deleteAnnouncement,
+  changeStatus
 };

--- a/server/v2/routes/admin.routes.js
+++ b/server/v2/routes/admin.routes.js
@@ -11,4 +11,10 @@ routes.delete(
   adminController.deleteAnnouncement
 );
 
+routes.patch(
+  '/announcement/:id/sold',
+  verifyToken,
+  adminController.changeStatus
+);
+
 export default routes;


### PR DESCRIPTION
## What does this PR do?
- Enable User admin to change the status of announcement 
## Description of tasks to be done?
- PATCH /api/v1/announcement/:id/sold
## How does this manually tested?
- Pull this branch
- Test the above endpoint with Post 
- Below is the body.
{
"status":"active"
} 